### PR TITLE
bbapply-embed boundary condition check

### DIFF
--- a/detector/bbApply.m
+++ b/detector/bbApply.m
@@ -347,7 +347,7 @@ bb(:,1:4)=intersect(bb(:,1:4),[1 1 w h]);
 for b=1:n
   M=char2img(sprintf('%.4g',bb(b,5)),fh); M=M{1}==0; [h,w]=size(M);
   y0=bb(b,2); y1=y0+h-1; x0=bb(b,1); x1=x0+w-1;
-  if( x0>=1 && y0>=1 && x1<=size(I,2) && y1<=size(I,2))
+  if( x0>=1 && y0>=1 && x1<=size(I,2) && y1<=size(I,1))
     Ir=I(y0:y1,x0:x1,1); Ig=I(y0:y1,x0:x1,2); Ib=I(y0:y1,x0:x1,3);
     Ir(M)=fcol(b,1); Ig(M)=fcol(b,2); Ib(M)=fcol(b,3);
     I(y0:y1,x0:x1,:)=cat(3,Ir,Ig,Ib);


### PR DESCRIPTION
This line checks whether the embedded box will fit in the passed image, presumably to avoid runtime exceptions.

However, both `x` and `y` locations are checked against the second dimension of the image, when I believe `y` should be checked against the first dimension. This stopped the exceptions for me. Maybe issuing a warning that some boxes are not being painted would be useful.