### PR TITLE
fix garbage dimensions on 64bit system

### DIFF
--- a/channels/private/gradientMex.cpp
+++ b/channels/private/gradientMex.cpp
@@ -319,7 +319,7 @@ void fhog( float *M, float *O, float *H, int h, int w, int binSize,
 #ifdef MATLAB_MEX_FILE
 // Create [hxwxd] mxArray array, initialize to 0 if c=true
 mxArray* mxCreateMatrix3( int h, int w, int d, mxClassID id, bool c, void **I ){
-  const int dims[3]={h,w,d}, n=h*w*d; int b; mxArray* M;
+  const size_t dims[3]={h,w,d}, n=h*w*d; int b; mxArray* M;
   if( id==mxINT32_CLASS ) b=sizeof(int);
   else if( id==mxDOUBLE_CLASS ) b=sizeof(double);
   else if( id==mxSINGLE_CLASS ) b=sizeof(float);


### PR DESCRIPTION
on a 64bit linux system (ubuntu 16), the function mxCreateMatrix3 fails to generate matrix with the correct dimensions. The issue is the use of int vs size_t. The function mxSetDimensions takes size_t as its inputs, but mxCreateMatrix3 passes int. on (my) 64bit system, int is 4 bytes, whereas size_t is 8 bytes. This caused garbage dimensions being assigned to the matrix.